### PR TITLE
feat(client): implement basic echo client with EXIT termination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ dkms.conf
 
 # Ignore all build files
 /build/
+
+# Ignore VSCode settings directory
+.vscode/

--- a/client/main.c
+++ b/client/main.c
@@ -36,6 +36,10 @@ int main(void)
         printf("Client: ");
         if (fgets(buffer, 1024, stdin) == NULL)
             break;
+        buffer[strcspn(buffer, "\n")] = '\0';
+
+        if (strcmp(buffer, "EXIT") == 0)
+            break;
 
         if (send(sockfd, buffer, strlen(buffer), 0) <= 0)
             break;

--- a/client/main.c
+++ b/client/main.c
@@ -4,11 +4,14 @@
 #include <unistd.h>
 #include <arpa/inet.h>
 
+#define BUFFER_SIZE 1024
+#define PORT 25000
+
 int main(void)
 {
     int sockfd;
     struct sockaddr_in server_addr;
-    char buffer[1024];
+    char buffer[BUFFER_SIZE];
 
     sockfd = socket(AF_INET, SOCK_STREAM, 0);
     if (sockfd == -1)
@@ -19,7 +22,7 @@ int main(void)
 
     memset(&server_addr, 0, sizeof(server_addr));
     server_addr.sin_family = AF_INET;
-    server_addr.sin_port = htons(25000);
+    server_addr.sin_port = htons(PORT);
     server_addr.sin_addr.s_addr = inet_addr("127.0.0.1");
 
     if (connect(sockfd, (struct sockaddr *)&server_addr, sizeof(server_addr)) == -1)
@@ -29,12 +32,12 @@ int main(void)
         exit(EXIT_FAILURE);
     }
 
-    printf("Connected to echo server at %s:%d\n", "127.0.0.1", 25000);
+    printf("Connected to echo server at %s:%d\n", "127.0.0.1", PORT);
 
     while (1)
     {
         printf("Client: ");
-        if (fgets(buffer, 1024, stdin) == NULL)
+        if (fgets(buffer, BUFFER_SIZE, stdin) == NULL)
             break;
         buffer[strcspn(buffer, "\n")] = '\0';
 
@@ -44,7 +47,7 @@ int main(void)
         if (send(sockfd, buffer, strlen(buffer), 0) <= 0)
             break;
 
-        ssize_t n = recv(sockfd, buffer, 1024 - 1, 0);
+        ssize_t n = recv(sockfd, buffer, BUFFER_SIZE - 1, 0);
         if (n <= 0)
             break;
 


### PR DESCRIPTION
## Description
This pull request introduces the initial implementation of the echo client.

### Changes
- Basic TCP client implemented to connect to the echo server at `127.0.0.1:25000`
- User can type messages to send to the server and receive echoed responses
- If the user inputs `"EXIT"`, the client terminates the connection gracefully

### Refactoring
- Defined `PORT` and `BUFFER_SIZE` macros to replace hardcoded values for better maintainability

### Miscellaneous
- Added `.vscode/` to `.gitignore` to exclude local development configurations