### PR TITLE
Pull Request: Add support for reusable socket, robust client handling, and server configuration cleanups

### DIFF
--- a/server/main.c
+++ b/server/main.c
@@ -42,32 +42,38 @@ int main(void)
 
     printf("Echo server is running on port %d...\n", PORT);
 
-    client_fd = accept(server_fd, (struct sockaddr *)&client_addr, &client_len);
-    if (client_fd == -1)
-    {
-        perror("accept");
-        close(server_fd);
-        exit(EXIT_FAILURE);
-    }
-
-    printf("Client connected: %s\n", inet_ntoa(client_addr.sin_addr));
-
     while (1)
     {
-        ssize_t n = recv(client_fd, buffer, BUFFER_SIZE - 1, 0);
-        if (n <= 0)
+        client_fd = accept(server_fd, (struct sockaddr *)&client_addr, &client_len);
+        if (client_fd == -1)
         {
-            printf("Client disconnected.\n");
-            break;
+            perror("accept");
+            close(server_fd);
+            exit(EXIT_FAILURE);
         }
 
-        buffer[n] = '\0';
-        printf("Received: %s", buffer);
+        printf("Client connected: %s\n", inet_ntoa(client_addr.sin_addr));
 
-        send(client_fd, buffer, n, 0);
+        while (1)
+        {
+            ssize_t n = recv(client_fd, buffer, BUFFER_SIZE - 1, 0);
+            if (n <= 0)
+            {
+                printf("Client disconnected.\n");
+                break;
+            }
+
+            buffer[n] = '\0';
+            printf("Received: %s\n", buffer);
+            fflush(stdout);
+
+            send(client_fd, buffer, n, 0);
+        }
+
+        shutdown(server_fd, SHUT_RDWR);
+        close(client_fd);
     }
 
-    close(client_fd);
     close(server_fd);
 
     return 0;

--- a/server/main.c
+++ b/server/main.c
@@ -21,6 +21,14 @@ int main(void)
         exit(EXIT_FAILURE);
     }
 
+    // SO_REUSEADDR 설정
+    int opt = 1;
+    if (setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) == -1)
+    {
+        perror("setsockopt");
+        exit(EXIT_FAILURE);
+    }
+
     memset(&server_addr, 0, sizeof(server_addr));
     server_addr.sin_family = AF_INET;
     server_addr.sin_port = htons(PORT);

--- a/server/main.c
+++ b/server/main.c
@@ -41,7 +41,7 @@ int main(void)
         exit(EXIT_FAILURE);
     }
 
-    if (listen(server_fd, 1) == -1)
+    if (listen(server_fd, SOMAXCONN) == -1)
     {
         perror("listen");
         close(server_fd);

--- a/server/main.c
+++ b/server/main.c
@@ -4,12 +4,15 @@
 #include <unistd.h>
 #include <arpa/inet.h>
 
+#define BUFFER_SIZE 1024
+#define PORT 25000
+
 int main(void)
 {
     int server_fd, client_fd;
     struct sockaddr_in server_addr, client_addr;
     socklen_t client_len = sizeof(client_addr);
-    char buffer[1024] = {0};
+    char buffer[BUFFER_SIZE] = {0};
 
     server_fd = socket(AF_INET, SOCK_STREAM, 0);
     if (server_fd == -1)
@@ -20,7 +23,7 @@ int main(void)
 
     memset(&server_addr, 0, sizeof(server_addr));
     server_addr.sin_family = AF_INET;
-    server_addr.sin_port = htons(25000);
+    server_addr.sin_port = htons(PORT);
     server_addr.sin_addr.s_addr = htonl(INADDR_ANY);
 
     if (bind(server_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)) == -1)
@@ -37,7 +40,7 @@ int main(void)
         exit(EXIT_FAILURE);
     }
 
-    printf("Echo server is running on port %d...\n", 25000);
+    printf("Echo server is running on port %d...\n", PORT);
 
     client_fd = accept(server_fd, (struct sockaddr *)&client_addr, &client_len);
     if (client_fd == -1)
@@ -51,7 +54,7 @@ int main(void)
 
     while (1)
     {
-        ssize_t n = recv(client_fd, buffer, 1024 - 1, 0);
+        ssize_t n = recv(client_fd, buffer, BUFFER_SIZE - 1, 0);
         if (n <= 0)
         {
             printf("Client disconnected.\n");

--- a/server/main.c
+++ b/server/main.c
@@ -78,7 +78,6 @@ int main(void)
             send(client_fd, buffer, n, 0);
         }
 
-        shutdown(server_fd, SHUT_RDWR);
         close(client_fd);
     }
 


### PR DESCRIPTION
## Summary of Changes

1. refactor(server): replace hardcoded values with `PORT` and `BUFFER_SIZE` macros
2. feat(server): persistently accept multiple client connections by moving `accept()` inside main loop
    - Modified server to continuously accept new client connections inside an infinite loop.
    - Prevents the server from shutting down after handling just one client.
3. feat(server): apply `SO_REUSEADDR` to allow port reuse on server restart
    - Applied `setsockopt()` with `SO_REUSEADDR` to allow immediate reuse of the port after server restarts.
    - Has no effect when using loopback address (127.0.0.1)
4. refactor(server): use `SOMAXCONN` for `listen()` to follow system-denied connection limit
    - Replaced hardcoded backlog value in `listen()` with `SOMAXCONN` to defer to system's max allowable pending connections.
5. fix(server): prevent server shutdown after client disconnects
    - Removed `shutdown(server_fd, SHUT_RDWR);` which was causing the server to stop listening after a client exits.
    - Ensures server continues to run and accept new client connections.

---

## Future Work

- Convert codebase to C++ and use STL containers for managing multiple simultaneous client sockets.
- Migrate from echo server to full chat server using `select()` or multithreading.