### PR TITLE
feat: integrate multi-threading and client recv thread for chatting functionality

### DIFF
--- a/server/main.cpp
+++ b/server/main.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <unistd.h>
 #include <cstring>
+#include <csignal>
 #include <arpa/inet.h>
 #include <list>
 
@@ -10,6 +11,7 @@ constexpr int PORT = 25000;
 
 pthread_spinlock_t g_spin;
 std::list<int> g_list_client;
+int g_server_fd;
 
 bool addUser(int sock_fd)
 {
@@ -61,12 +63,36 @@ void *threadFunction(void *arg)
     }
 }
 
+void signalHandler(int signum)
+{
+    std::list<int>::iterator it;
+
+    std::cout << "\n[INFO] Interrupt signal (" << signum << ") received. Shutting down..." << std::endl;
+
+    shutdown(g_server_fd, SHUT_RDWR);
+
+    pthread_spin_lock(&g_spin);
+    for (it = g_list_client.begin(); it != g_list_client.end(); it++)
+        close(*it);
+
+    g_list_client.clear();
+    pthread_spin_unlock(&g_spin);
+
+    sleep(1);
+    pthread_spin_destroy(&g_spin);
+    close(g_server_fd);
+
+    exit(signum);
+}
+
 int main(void)
 {
     pthread_spin_init(&g_spin, PTHREAD_PROCESS_PRIVATE);
 
-    int server_fd = socket(AF_INET, SOCK_STREAM, 0);
-    if (server_fd == -1)
+    signal(SIGINT, signalHandler);
+
+    int g_server_fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (g_server_fd == -1)
     {
         perror("socket");
         return EXIT_FAILURE;
@@ -74,7 +100,7 @@ int main(void)
 
     // SO_REUSEADDR 설정
     int opt = 1;
-    if (setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) == -1)
+    if (setsockopt(g_server_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) == -1)
     {
         perror("setsockopt");
         return EXIT_FAILURE;
@@ -85,17 +111,17 @@ int main(void)
     server_addr.sin_port = htons(PORT);
     server_addr.sin_addr.s_addr = htonl(INADDR_ANY);
 
-    if (bind(server_fd, reinterpret_cast<sockaddr *>(&server_addr), sizeof(server_addr)) == -1)
+    if (bind(g_server_fd, reinterpret_cast<sockaddr *>(&server_addr), sizeof(server_addr)) == -1)
     {
         perror("bind");
-        close(server_fd);
+        close(g_server_fd);
         return EXIT_FAILURE;
     }
 
-    if (listen(server_fd, SOMAXCONN) == -1)
+    if (listen(g_server_fd, SOMAXCONN) == -1)
     {
         perror("listen");
-        close(server_fd);
+        close(g_server_fd);
         return EXIT_FAILURE;
     }
 
@@ -107,11 +133,11 @@ int main(void)
 
     while (true)
     {
-        int client_fd = accept(server_fd, reinterpret_cast<sockaddr *>(&client_addr), &client_len);
+        int client_fd = accept(g_server_fd, reinterpret_cast<sockaddr *>(&client_addr), &client_len);
         if (client_fd == -1)
         {
             perror("accept");
-            close(server_fd);
+            close(g_server_fd);
             return EXIT_FAILURE;
         }
 
@@ -131,8 +157,7 @@ int main(void)
         pthread_detach(tid);
     }
 
-    close(server_fd);
-    pthread_spin_destroy(&g_spin);
+    std::cout << "Closing chatting server..." << std::endl;
 
     return 0;
 }

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -1,6 +1,7 @@
 #include <pthread.h>
 #include <iostream>
 #include <unistd.h>
+#include <cstring>
 #include <arpa/inet.h>
 
 constexpr int BUFFER_SIZE = 1024;
@@ -28,6 +29,7 @@ void *threadFunction(void *arg)
         std::cout << "Received: " << buffer << std::endl;
 
         send(client_fd, buffer, received, 0);
+        memset(buffer, 0, BUFFER_SIZE);
     }
 }
 

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -20,6 +20,17 @@ bool addUser(int sock_fd)
     return true;
 }
 
+void send_chatting_message(char *param)
+{
+    int length = strlen(param);
+    std::list<int>::iterator it;
+
+    pthread_spin_lock(&g_spin);
+    for (it = g_list_client.begin(); it != g_list_client.end(); it++)
+        send(*it, param, sizeof(char) * (length + 1), 0);
+    pthread_spin_unlock(&g_spin);
+}
+
 void *threadFunction(void *arg)
 {
     int client_fd = *(int *)arg;
@@ -45,7 +56,7 @@ void *threadFunction(void *arg)
         buffer[received] = '\0';
         std::cout << "Received: " << buffer << std::endl;
 
-        send(client_fd, buffer, received, 0);
+        send_chatting_message(buffer);
         memset(buffer, 0, BUFFER_SIZE);
     }
 }
@@ -111,7 +122,7 @@ int main(void)
         }
 
         pthread_t tid;
-        if(pthread_create(&tid, nullptr, threadFunction, &client_fd) != 0)
+        if (pthread_create(&tid, nullptr, threadFunction, &client_fd) != 0)
         {
             perror("pthread_create");
             return EXIT_FAILURE;

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -121,6 +121,7 @@ int main(void)
     }
 
     close(server_fd);
+    pthread_spin_destroy(&g_spin);
 
     return 0;
 }


### PR DESCRIPTION
This PR merges the full chatting server implementation into the main branch.

### Features integrated:
- Multi-threaded server (`feature/multithreaded-server`)
  - Each client is handled in a dedicated thread
  - Connected clients are tracked in a global list with spinlock protection
  - Broadcast functionality sends messages to all connected clients
  - Cleanup of client sockets upon disconnection
- Client receive thread (`feature/client-recv-thread`)
  - Clients receive messages asynchronously in a separate thread
- Graceful shutdown
  - Server handles SIGINT (Ctrl+C) to close server socket and release spinlock